### PR TITLE
Passes response.regions and response.regions[scope.region] as trusted HTML to the scope.

### DIFF
--- a/modules/pages/scripts/pages.js
+++ b/modules/pages/scripts/pages.js
@@ -60,18 +60,21 @@
         return {
             restrict: 'A',
             scope: {
-                region: '@'
+                region: '@',
+                slug: '@'
             },
             replace: true,
             templateUrl: 'templates/feincms/pages/region.html',
             link: function (scope, element, attrs) {
                 var url = PROJECT_SETTINGS.API_ROOT + MODULE_SETTINGS.PAGES_ENDPOINT;
 
-                var slug = $location.$$path;
-                // Remove the first and last / from the path.
-                slug = slug.replace(/^\/+|\/+$/g, '');
+                if (angular.isUndefined(scope.slug)) {
+                    scope.slug = $location.$$path;
+                    // Remove the first and last / from the path.
+                    scope.slug = scope.slug.replace(/^\/+|\/+$/g, '');
+                }
 
-                url = url + '/' + slug;
+                url = url + '/' + scope.slug;
 
                 drf.loadItem(url)
                     .then(function (response) {


### PR DESCRIPTION
Previously, the output would have been pruned by Angular not to include, among others, IDs. This makes anchors useless, on which some ePatient sites, including a number of ePatient sites' privacy sections' table of contents rely. To alleviate this, the `pageGroup` and the `feincmsPageRegion` directives were amended so as to return their original result as angular trusted HTML (`$sce.trustAsHtml()`).
