### PR TITLE
Make sure we can use multiple feincms page directives in the same scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# 2.0.1
+# 3.0.0
+* Breaking change: Support using directive multiple times in a single scope
+
+### 2.0.1
 
 * Upgrade Angular compatibility to include 1.3, 1.4 and 1.5.
 * Upgrade djangular-rest-framework compatibility to include 2, 3 and 4.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 angular-feincms
 ===============
+
+### Directive
+`feincms-page` attribute should be an angular expression. If you pass a simple slug it needs to be passed as a quoted string.
+
+Example:
+```
+ <div feincms-page="'page-slug'" >
+    <div bind-html-compile="page.regions.main"></div>
+    <div bind-html-compile="page.regions.sidebar"></div>
+</div>
+```

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ angular-feincms
 
 Example:
 ```
- <div feincms-page="'page-slug'" >
-    <div bind-html-compile="page.regions.main"></div>
-    <div bind-html-compile="page.regions.sidebar"></div>
+ <div feincms-page="'pageSlug'">
+    <div bind-html-compile="feincmsPages.pageSlug.regions.main"></div>
+    <div bind-html-compile="feincmsPages.pageSlug.regions.sidebar"></div>
 </div>
 ```

--- a/modules/pages/scripts/pages.js
+++ b/modules/pages/scripts/pages.js
@@ -74,11 +74,12 @@
             restrict: 'A',
             scope: false,
             link: function (scope, element, attrs) {
+                scope.feincmsPages = {};
                 scope.$watch(attrs.feincmsPage, function (field) {
                     var slug = scope.$eval(attrs.feincmsPage);
                     if (angular.isDefined(slug)) {
                         loadPage(slug).then(function (response) {
-                            scope.page = response;
+                            scope.feincmsPages[slug] = response;
                         });
                     }
                 });


### PR DESCRIPTION
This directive could not be used multiple times within the same scope, as the scope was not isolated. This meant the last one to load would assign it's value to `scope.page` and all directives would show the same data.